### PR TITLE
Feature: layout parameter for add nodes tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,14 @@ Create a new empty diagram file.
 
 ### add_nodes
 
-Add one or more nodes to an existing diagram in a single operation.
+Add one or more nodes to an existing diagram in a single operation. Optionally run an automatic layout after insertion.
 
 **Parameters:**
 - `file_path` (string, required): Path to the diagram file
+- `layout` (object, optional): Automatic layout configuration
+  - `algorithm` (string, required if `layout` is provided): One of `hierarchical`, `circle`, `organic`, `compact-tree`, `radial-tree`, `partition`, `stack`
+  - `options` (object, optional): Algorithm-specific options
+    - For `hierarchical` only: `direction` ∈ `"top-down" | "left-right"` (default: `"top-down"`)
 - `nodes` (array, required): Array of node objects to add, each containing:
   - `id` (string, required): Unique identifier for the node
   - `title` (string, required): Display label (supports newlines with `\n`)
@@ -157,6 +161,24 @@ Add one or more nodes to an existing diagram in a single operation.
   ]
 }
 ```
+
+**Example (With Layout):**
+```json
+{
+  "file_path": "./diagrams/system-architecture.drawio.svg",
+  "layout": {
+    "algorithm": "hierarchical",
+    "options": { "direction": "left-right" }
+  },
+  "nodes": [
+    { "id": "api", "title": "API", "kind": "Rectangle", "x": 40, "y": 40 },
+    { "id": "service", "title": "Service", "kind": "Rectangle", "x": 200, "y": 40 },
+    { "id": "db", "title": "DB", "kind": "Cylinder", "x": 360, "y": 40 }
+  ]
+}
+```
+
+Note: The layout runs once after all insertions and considers existing edges in the diagram file. For best results when edges are created or modified later, a dedicated `layout_diagram` tool is recommended (to be added).
 
 ### link_nodes
 

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -125,41 +125,6 @@ export class Graph {
     return this
   }
 
-  hierarchicalLayout(direction = DIRECTION_TOP_DOWN) {
-    const dir = DIR_TO_MX_DIRECTION[direction]
-    const layout = new mxHierarchicalLayout(this.graph, dir);
-    return this.runLayout(layout, Object.values(this.model.cells)[1])
-  }
-
-  circleLayout() {
-    const layout = new mxCircleLayout(this.graph);
-    return this.runLayout(layout)
-  }
-
-  organicLayout() {
-    const layout = new mxFastOrganicLayout(this.graph);
-    return this.runLayout(layout)
-  }
-
-  compactTreeLayout() {
-    const layout = new mxCompactTreeLayout(this.graph);
-    return this.runLayout(layout)
-  }
-
-  radialTreeLayout() {
-    const layout = new mxRadialTreeLayout(this.graph);
-    return this.runLayout(layout)
-  }
-
-  partitionLayout() {
-    const layout = new mxPartitionLayout(this.graph);
-    return this.runLayout(layout)
-  }
-
-  stackLayout() {
-    const layout = new mxStackLayout(this.graph);
-    return this.runLayout(layout)
-  }
 
   /**
    * Applies a layout algorithm to the graph.
@@ -191,31 +156,31 @@ export class Graph {
               options.direction !== DIRECTION_TOP_DOWN && options.direction !== DIRECTION_LEFT_RIGHT )
             throw new Error( `Invalid hierarchical direction: ${options.direction}. Allowed: ${DIRECTION_TOP_DOWN}, ${DIRECTION_LEFT_RIGHT}` );
 
-        this.hierarchicalLayout(options.direction);
+        this.runLayout(new mxHierarchicalLayout(this.graph, DIR_TO_MX_DIRECTION[options.direction]), Object.values(this.model.cells)[1]);
         break;
       }
       case LAYOUT_CIRCLE: {
-        this.circleLayout();
+        this.runLayout(new mxCircleLayout(this.graph));
         break;
       }
       case LAYOUT_ORGANIC: {
-        this.organicLayout();
+        this.runLayout(new mxFastOrganicLayout(this.graph));
         break;
       }
       case LAYOUT_COMPACT_TREE: {
-        this.compactTreeLayout();
+        this.runLayout(new mxCompactTreeLayout(this.graph));
         break;
       }
       case LAYOUT_RADIAL_TREE: {
-        this.radialTreeLayout();
+        this.runLayout(new mxRadialTreeLayout(this.graph));
         break;
       }
       case LAYOUT_PARTITION: {
-        this.partitionLayout();
+        this.runLayout(new mxPartitionLayout(this.graph));
         break;
       }
       case LAYOUT_STACK: {
-        this.stackLayout();
+        this.runLayout(new mxStackLayout(this.graph));
         break;
       }
       default: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { RemoveNodesTool } from './mcp/RemoveNodesTool.js';
 
 new McpServer({
   name: 'drawio-mcp',
-  version: '1.0.0',
+  version: '1.1.0',
   tools: [
     new NewDiagramTool(),
     new AddNodeTool(),

--- a/src/mcp/EditNodeTool.ts
+++ b/src/mcp/EditNodeTool.ts
@@ -54,7 +54,7 @@ export class EditNodeTool implements Tool {
     for (const node of nodes) {
       const { id, title, kind, x, y, width, height } = node;
       
-      graph.editNode({ id, title, kind, x, y, width, height });
+      graph.editNode({ id, title, kind: kind ? Graph.normalizeKind(kind) : undefined, x, y, width, height });
     }
 
     await this.fileManager.saveGraphToSvg(graph, file_path);

--- a/src/mxgraph/index.ts
+++ b/src/mxgraph/index.ts
@@ -1,7 +1,7 @@
 import './jsdom.js';
 import mxgraph from 'mxgraph';
 
-export const { mxGraph, mxGraphModel, mxGeometry, mxCodec, mxPoint, mxUtils, mxHierarchicalLayout, mxConstants, mxCircleLayout, mxSwimlaneLayout } = mxgraph({
+export const { mxGraph, mxGraphModel, mxGeometry, mxCodec, mxPoint, mxUtils, mxHierarchicalLayout, mxConstants, mxCircleLayout, mxSwimlaneLayout, mxFastOrganicLayout, mxCompactTreeLayout, mxRadialTreeLayout, mxPartitionLayout, mxStackLayout } = mxgraph({
   mxImageBasePath: "./src/images",
   mxBasePath: "./src"
 });


### PR DESCRIPTION

Add optional automatic layout to the `add_nodes` tool, enabling server-side arrangement of diagram nodes after insertion. Centralizes layout logic in `Graph.applyLayout` and updates docs.

#### Key Changes
- add_nodes: Accepts optional `layout: { algorithm: string; options?: any }`
  - Supported algorithms: hierarchical, circle, organic, compact-tree, radial-tree, partition, stack
  - Hierarchical options: direction = "top-down" (default) | "left-right"
  - Runs a single layout pass after all nodes are added; considers existing edges
- Graph: New `applyLayout` method; validation and clear errors for invalid algorithm/direction
- Kind normalization: Use "Ellipse"; accept "Elipse" as a runtime alias
- Docs: README and tool schema updated to describe layout usage and examples
- TODO: Note to introduce a `layout_diagram` tool for decoupled re-layout after linking

#### Motivation
- Simplify creating readable diagrams programmatically by applying layout automatically
- Provide a unified, reusable layout entry point for future features

#### Backward Compatibility
- Existing behavior unchanged when `layout` is omitted
- "Elipse" still accepted at runtime, but "Ellipse" is now the documented kind