### PR TITLE
feature: add support for RoundedRectangle nodes in add/edit node tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Add one or more nodes to an existing diagram in a single operation. Optionally r
   - `parent` (string, optional): Parent node ID (default: "root")
   - `width` (number, optional): Custom width
   - `height` (number, optional): Custom height
+  - `corner_radius` (integer, optional): Corner radius in pixels (≥ 1). Only applies to `RoundedRectangle`. Default is 12 when `kind` is `RoundedRectangle` and `corner_radius` is omitted. The effective visual radius is capped by draw.io/mxGraph to at most half of the shorter side of the node.
 
 **Available Node Types:**
 - `Rectangle`: Standard rectangular node
@@ -113,6 +114,7 @@ Add one or more nodes to an existing diagram in a single operation. Optionally r
 - `Step`: Process step shape
 - `Actor`: UML actor (stick figure)
 - `Text`: Text-only node
+- `RoundedRectangle`: Rectangle with rounded corners (supports `corner_radius` in pixels)
 
 **Example (Single Node):**
 ```json
@@ -248,6 +250,7 @@ Modify properties of one or more existing nodes or edges in a single operation.
   - `y` (number, optional): New Y coordinate (nodes only)
   - `width` (number, optional): New width (nodes only)
   - `height` (number, optional): New height (nodes only)
+  - `corner_radius` (integer, optional): Corner radius in pixels (≥ 1). Applies when the node is `RoundedRectangle`. If switching kind to `RoundedRectangle` and omitted, default 12 is applied. Ignored for other kinds.
 
 **Example (Single Node):**
 ```json

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -16,6 +16,11 @@ const DIR_TO_MX_DIRECTION = {
   [DIRECTION_LEFT_RIGHT]: mxConstants.DIRECTION_WEST
 }
 
+const DEFAULT_CORNER_RADIUS = 12
+const KIND_ROUNDED_RECTANGLE = 'RoundedRectangle'
+const PROP_ARC_SIZE = 'arcSize'
+const PROP_ABSOLUTE_ARC_SIZE = 'absoluteArcSize'
+
 export class Graph {
   static Kinds = {
     Rectangle: { style: { rounded: 1, whiteSpace: 'wrap', html: 1 }, width: 120, height: 60 },
@@ -27,6 +32,7 @@ export class Graph {
     Step: { style: 'shape=step;perimeter=stepPerimeter;whiteSpace=wrap;html=1;fixedSize=1;', width: 120, height: 80 },
     Actor: { style: 'shape=umlActor;verticalLabelPosition=bottom;verticalAlign=top;html=1;outlineConnect=0;', width: 30, height: 60 },
     Text: { style: 'text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;', width: 60, height: 30 },
+    RoundedRectangle: { style: `whiteSpace=wrap;html=1;rounded=1;absoluteArcSize=1;arcSize=${DEFAULT_CORNER_RADIUS * 2}`, width: 120, height: 60 },
   }
 
   static normalizeKind(kind: string) {
@@ -57,22 +63,118 @@ export class Graph {
     }, '')
   }
 
-  addNode({ id, title, parent = 'root', kind = 'Rectangle', x = 10, y = 10, ...rest }) {
+  /**
+   * Parses a style definition into a key-value object.
+   * 
+   * Handles both string and object style formats:
+   * - String format: "key1=value1;key2=value2;" (semicolon-separated key=value pairs)
+   * - Object format: { key1: "value1", key2: "value2" } (plain object)
+   * 
+   * For string styles, empty values (e.g., "key=") are converted to empty strings.
+   * For object styles, the input is shallow copied to avoid mutation.
+   * 
+   * @param style - Style definition as either a semicolon-separated string or object
+   * @returns Object with style properties as key-value pairs
+   * 
+   * @example
+   * parseStyle("rounded=1;whiteSpace=wrap;html=1")
+   * // Returns: { rounded: "1", whiteSpace: "wrap", html: "1" }
+   * 
+   * @example
+   * parseStyle({ rounded: 1, whiteSpace: "wrap" })
+   * // Returns: { rounded: 1, whiteSpace: "wrap" }
+   */
+  private parseStyle(style: any): Record<string, string> {
+    if (typeof style === 'string') {
+      return style.split(';').filter(Boolean).reduce((acc: Record<string, string>, kv) => {
+        const [k, v] = kv.split('=');
+        acc[k] = v === undefined ? '' : v;
+        return acc;
+      }, {});
+    }
+    return { ...style };
+  }
+
+  /**
+   * Converts a style object into a semicolon-separated style string.
+   * 
+   * This function is the inverse of parseStyle(), converting a key-value object
+   * back into the string format used by mxGraph. Properties with undefined values
+   * are skipped, while properties with falsy values (empty string, 0, false) are
+   * included with just the key name (no equals sign).
+   * 
+   * @param style - Object with style properties as key-value pairs
+   * @returns Semicolon-separated style string in format "key1=value1;key2;key3=value3;"
+   * 
+   * @example
+   * stringifyStyle({ rounded: "1", whiteSpace: "wrap", html: "1" })
+   * // Returns: "rounded=1;whiteSpace=wrap;html=1;"
+   * 
+   * @example
+   * stringifyStyle({ rounded: "", whiteSpace: "wrap" })
+   * // Returns: "rounded;whiteSpace=wrap;"
+   */
+  private stringifyStyle(style: Record<string, any>): string {
+    return Object.entries(style).reduce((tmp, [key, value]) => {
+      return value === undefined ? tmp : tmp += key + (value ? `=${value}` : '') + ';'
+    }, '');
+  }
+
+  
+
+  /**
+   * Adjusts the style string for a specific node kind, applying kind-specific modifications.
+   * 
+   * For RoundedRectangle nodes, this function modifies the corner radius by setting:
+   * - absoluteArcSize to '1' to enable absolute arc sizing
+   * - arcSize to the calculated value (corner_radius * 2, default to 24)
+   * 
+   * @param style - The base style string to modify
+   * @param kind - The node kind (e.g., 'RoundedRectangle', 'Rectangle', etc.)
+   * @param corner_radius - The desired corner radius in pixels (only applies to RoundedRectangle)
+   * @returns The modified style string with kind-specific adjustments applied
+   */
+  private adjustStyleByKind(style: string, kind: string, corner_radius: number) : string {
+    if (kind === KIND_ROUNDED_RECTANGLE) {
+      const styleObj = this.parseStyle(style);
+      if (corner_radius !== undefined) {
+        const cr = parseInt(String(corner_radius), 10);
+        styleObj[PROP_ABSOLUTE_ARC_SIZE] = '1';
+        const arcSize = !isNaN(cr) && cr >= 1 ? cr * 2 : DEFAULT_CORNER_RADIUS * 2;
+        styleObj[PROP_ARC_SIZE] = String(arcSize);
+      }
+      // console.error(`adjusted style: ${this.stringifyStyle(styleObj)}`);
+      return this.stringifyStyle(styleObj);
+    }
+    return style;
+  }
+
+  
+  addNode({ id, title, parent = 'root', kind = 'Rectangle', x = 10, y = 10, corner_radius, ...rest }) {
     const normalizedKind = Graph.normalizeKind(kind)
     const { style, width, height } = { ...Graph.Kinds[normalizedKind], ...rest }
+    
     const to = parent === 'root' ? this.root : this.model.getCell(parent)
     const node = this.graph.insertVertex(to, id, title, Number(x), Number(y), width, height);
-    node.setStyle(style)
+    node.setStyle(this.adjustStyleByKind(style, normalizedKind, corner_radius));
     return node
   }
 
-  editNode({ id, title, kind, x, y, width, height }) {
+  editNode({ id, title, kind, x, y, width, height, corner_radius }) {
     const node = this.model.getCell(id);
 
     if (!node) throw new Error(`Node not found`);
-
+    const normalizedKind = Graph.normalizeKind(kind)
     if (title) node.setValue(title);
-    if (kind) node.setStyle(Graph.Kinds[Graph.normalizeKind(kind)].style);
+    if (kind) node.setStyle(Graph.Kinds[normalizedKind].style);
+
+    // if it's rounded, apply the corner radius
+    const isRounded = normalizedKind === KIND_ROUNDED_RECTANGLE;
+    if (isRounded && corner_radius !== undefined) {
+      const currentStyleStr = node.getStyle && node.getStyle() ? String(node.getStyle()) : '';
+      node.setStyle(this.adjustStyleByKind(currentStyleStr, normalizedKind, corner_radius));
+    }
+    // if the geometry is changed, update the geometry
     if (x !== undefined || y !== undefined || width !== undefined || height !== undefined) {
       const geometry = node.getGeometry();
       node.setGeometry(new mxGeometry(

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { RemoveNodesTool } from './mcp/RemoveNodesTool.js';
 
 new McpServer({
   name: 'drawio-mcp',
-  version: '1.1.0',
+  version: '1.2.0',
   tools: [
     new NewDiagramTool(),
     new AddNodeTool(),

--- a/src/mcp/AddNodeTool.ts
+++ b/src/mcp/AddNodeTool.ts
@@ -48,7 +48,8 @@ export class AddNodeTool implements Tool {
                 x: { type: 'number', description: 'X coordinate' },
                 y: { type: 'number', description: 'Y coordinate' },
                 width: { type: 'number', description: 'Custom width (optional)' },
-                height: { type: 'number', description: 'Custom height (optional)' }
+                height: { type: 'number', description: 'Custom height (optional)' },
+                corner_radius: { type: 'integer', minimum: 1, description: 'Corner radius in pixels (≥1), only for kind RoundedRectangle' }
               },
               required: ['id', 'title', 'x', 'y', 'kind']
             }
@@ -67,7 +68,7 @@ export class AddNodeTool implements Tool {
     const graph = await this.fileManager.loadGraphFromSvg(file_path);
 
     for (const node of nodes) {
-      const { id, title, kind, parent, x, y, width, height } = node;
+      const { id, title, kind, parent, x, y, width, height, corner_radius } = node;
 
       graph.addNode({ 
         id, 
@@ -77,7 +78,8 @@ export class AddNodeTool implements Tool {
         x: Number(x), 
         y: Number(y),
         ...(width && { width: Number(width) }),
-        ...(height && { height: Number(height) })
+        ...(height && { height: Number(height) }),
+        ...(corner_radius && { corner_radius: Number(corner_radius) })
       });
     }
 

--- a/src/mcp/EditNodeTool.ts
+++ b/src/mcp/EditNodeTool.ts
@@ -33,7 +33,8 @@ export class EditNodeTool implements Tool {
                 x: { type: 'number', description: 'New node X coordinate, only appliable to nodes (optional)' },
                 y: { type: 'number', description: 'New node Y coordinate, only appliable to nodes (optional)' },
                 width: { type: 'number', description: 'New node width, only appliable to nodes (optional)' },
-                height: { type: 'number', description: 'New node height, only appliable to nodes (optional)' }
+                height: { type: 'number', description: 'New node height, only appliable to nodes (optional)' },
+                corner_radius: { type: 'integer', minimum: 1, description: 'Corner radius in pixels (≥1), applies to RoundedRectangle' }
               },
               required: ['id']
             }
@@ -52,9 +53,9 @@ export class EditNodeTool implements Tool {
     const graph = await this.fileManager.loadGraphFromSvg(file_path);
 
     for (const node of nodes) {
-      const { id, title, kind, x, y, width, height } = node;
+      const { id, title, kind, x, y, width, height, corner_radius } = node;
       
-      graph.editNode({ id, title, kind: kind ? Graph.normalizeKind(kind) : undefined, x, y, width, height });
+      graph.editNode({ id, title, kind: kind ? Graph.normalizeKind(kind) : undefined, x, y, width, height, ...(corner_radius && { corner_radius: Number(corner_radius) }) });
     }
 
     await this.fileManager.saveGraphToSvg(graph, file_path);


### PR DESCRIPTION
Add new `RoundedRectangle` node kind
- per-node corner radius
- update Graph to apply string styles and preserve edits
- document the feature in README