### PR TITLE
Added Support for Colors and Multi-point Lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Add one or more nodes to an existing diagram in a single operation. Optionally r
   - `width` (number, optional): Custom width
   - `height` (number, optional): Custom height
   - `corner_radius` (integer, optional): Corner radius in pixels (≥ 1). Only applies to `RoundedRectangle`. Default is 12 when `kind` is `RoundedRectangle` and `corner_radius` is omitted. The effective visual radius is capped by draw.io/mxGraph to at most half of the shorter side of the node.
+  - `fillColor` (string, optional): Background fill color (hex, e.g., `#dae8fc`)
+  - `strokeColor` (string, optional): Border color (hex, e.g., `#6c8ebf`)
+  - `fontColor` (string, optional): Text color (hex, e.g., `#333333`)
+  - `strokeWidth` (number, optional): Border width in pixels
+  - `fontSize` (number, optional): Font size in pixels
+  - `fontStyle` (integer, optional): Font style bitmask: 1=bold, 2=italic, 4=underline (combinable, e.g., 3=bold+italic)
+  - `fontFamily` (string, optional): Font family name (e.g., `Helvetica`)
+  - `opacity` (number, optional): Overall opacity (0=transparent, 100=opaque)
 
 **Available Node Types:**
 - `Rectangle`: Standard rectangular node
@@ -182,6 +190,36 @@ Add one or more nodes to an existing diagram in a single operation. Optionally r
 
 Note: The layout runs once after all insertions and considers existing edges in the diagram file. For best results when edges are created or modified later, a dedicated `layout_diagram` tool is recommended (to be added).
 
+**Example (With Styling):**
+```json
+{
+  "file_path": "./diagrams/styled.drawio.svg",
+  "nodes": [
+    {
+      "id": "web-app",
+      "title": "Web App",
+      "kind": "RoundedRectangle",
+      "x": 100,
+      "y": 50,
+      "fillColor": "#dae8fc",
+      "strokeColor": "#6c8ebf",
+      "fontStyle": 1,
+      "fontSize": 14
+    },
+    {
+      "id": "database",
+      "title": "Database",
+      "kind": "Cylinder",
+      "x": 300,
+      "y": 50,
+      "fillColor": "#d5e8d4",
+      "strokeColor": "#82b366",
+      "opacity": 80
+    }
+  ]
+}
+```
+
 ### link_nodes
 
 Create one or more connections between existing nodes in a single operation.
@@ -195,6 +233,13 @@ Create one or more connections between existing nodes in a single operation.
   - `dashed` (boolean, optional): Whether to use dashed line style
   - `reverse` (boolean, optional): Whether to reverse arrow direction
   - `undirected` (boolean, optional): Create an undirected edge (no arrows). Overrides `reverse`.
+  - `strokeColor` (string, optional): Line color (hex, e.g., `#6c8ebf`)
+  - `fontColor` (string, optional): Label text color (hex, e.g., `#333333`)
+  - `strokeWidth` (number, optional): Line width in pixels
+  - `fontSize` (number, optional): Label font size in pixels
+  - `fontStyle` (integer, optional): Font style bitmask: 1=bold, 2=italic, 4=underline (combinable)
+  - `fontFamily` (string, optional): Label font family name (e.g., `Helvetica`)
+  - `opacity` (number, optional): Overall opacity (0=transparent, 100=opaque)
 
 **Example (Single Connection):**
 ```json
@@ -272,6 +317,14 @@ Modify properties of one or more existing nodes or edges in a single operation.
   - `width` (number, optional): New width (nodes only)
   - `height` (number, optional): New height (nodes only)
   - `corner_radius` (integer, optional): Corner radius in pixels (≥ 1). Applies when the node is `RoundedRectangle`. If switching kind to `RoundedRectangle` and omitted, default 12 is applied. Ignored for other kinds.
+  - `fillColor` (string, optional): Background fill color (hex, e.g., `#dae8fc`)
+  - `strokeColor` (string, optional): Border/line color (hex, e.g., `#6c8ebf`)
+  - `fontColor` (string, optional): Text color (hex, e.g., `#333333`)
+  - `strokeWidth` (number, optional): Border/line width in pixels
+  - `fontSize` (number, optional): Font size in pixels
+  - `fontStyle` (integer, optional): Font style bitmask: 1=bold, 2=italic, 4=underline (combinable)
+  - `fontFamily` (string, optional): Font family name (e.g., `Helvetica`)
+  - `opacity` (number, optional): Overall opacity (0=transparent, 100=opaque)
 
 **Example (Single Node):**
 ```json

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "start": "tsx src/index.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "prepare": "tsc"
   },
   "keywords": [
     "mcp",

--- a/src/mcp/AddNodeTool.ts
+++ b/src/mcp/AddNodeTool.ts
@@ -49,7 +49,15 @@ export class AddNodeTool implements Tool {
                 y: { type: 'number', description: 'Y coordinate' },
                 width: { type: 'number', description: 'Custom width (optional)' },
                 height: { type: 'number', description: 'Custom height (optional)' },
-                corner_radius: { type: 'integer', minimum: 1, description: 'Corner radius in pixels (≥1), only for kind RoundedRectangle' }
+                corner_radius: { type: 'integer', minimum: 1, description: 'Corner radius in pixels (≥1), only for kind RoundedRectangle' },
+                fillColor: { type: 'string', description: 'Background fill color (hex, e.g., "#dae8fc")' },
+                strokeColor: { type: 'string', description: 'Border color (hex, e.g., "#6c8ebf")' },
+                fontColor: { type: 'string', description: 'Text color (hex, e.g., "#333333")' },
+                strokeWidth: { type: 'number', description: 'Border width in pixels' },
+                fontSize: { type: 'number', description: 'Font size in pixels' },
+                fontStyle: { type: 'integer', description: 'Font style bitmask: 1=bold, 2=italic, 4=underline (combinable, e.g., 3=bold+italic)' },
+                fontFamily: { type: 'string', description: 'Font family name (e.g., "Helvetica")' },
+                opacity: { type: 'number', minimum: 0, maximum: 100, description: 'Overall opacity (0=transparent, 100=opaque)' }
               },
               required: ['id', 'title', 'x', 'y', 'kind']
             }
@@ -68,7 +76,7 @@ export class AddNodeTool implements Tool {
     const graph = await this.fileManager.loadGraphFromSvg(file_path);
 
     for (const node of nodes) {
-      const { id, title, kind, parent, x, y, width, height, corner_radius } = node;
+      const { id, title, kind, parent, x, y, width, height, corner_radius, fillColor, strokeColor, fontColor, strokeWidth, fontSize, fontStyle, fontFamily, opacity } = node;
 
       graph.addNode({ 
         id, 
@@ -79,7 +87,15 @@ export class AddNodeTool implements Tool {
         y: Number(y),
         ...(width && { width: Number(width) }),
         ...(height && { height: Number(height) }),
-        ...(corner_radius && { corner_radius: Number(corner_radius) })
+        ...(corner_radius && { corner_radius: Number(corner_radius) }),
+        ...(fillColor !== undefined && { fillColor }),
+        ...(strokeColor !== undefined && { strokeColor }),
+        ...(fontColor !== undefined && { fontColor }),
+        ...(strokeWidth !== undefined && { strokeWidth }),
+        ...(fontSize !== undefined && { fontSize }),
+        ...(fontStyle !== undefined && { fontStyle }),
+        ...(fontFamily !== undefined && { fontFamily }),
+        ...(opacity !== undefined && { opacity }),
       });
     }
 

--- a/src/mcp/EditNodeTool.ts
+++ b/src/mcp/EditNodeTool.ts
@@ -34,7 +34,15 @@ export class EditNodeTool implements Tool {
                 y: { type: 'number', description: 'New node Y coordinate, only appliable to nodes (optional)' },
                 width: { type: 'number', description: 'New node width, only appliable to nodes (optional)' },
                 height: { type: 'number', description: 'New node height, only appliable to nodes (optional)' },
-                corner_radius: { type: 'integer', minimum: 1, description: 'Corner radius in pixels (≥1), applies to RoundedRectangle' }
+                corner_radius: { type: 'integer', minimum: 1, description: 'Corner radius in pixels (≥1), applies to RoundedRectangle' },
+                fillColor: { type: 'string', description: 'Background fill color (hex, e.g., "#dae8fc")' },
+                strokeColor: { type: 'string', description: 'Border color (hex, e.g., "#6c8ebf")' },
+                fontColor: { type: 'string', description: 'Text color (hex, e.g., "#333333")' },
+                strokeWidth: { type: 'number', description: 'Border width in pixels' },
+                fontSize: { type: 'number', description: 'Font size in pixels' },
+                fontStyle: { type: 'integer', description: 'Font style bitmask: 1=bold, 2=italic, 4=underline (combinable, e.g., 3=bold+italic)' },
+                fontFamily: { type: 'string', description: 'Font family name (e.g., "Helvetica")' },
+                opacity: { type: 'number', minimum: 0, maximum: 100, description: 'Overall opacity (0=transparent, 100=opaque)' }
               },
               required: ['id']
             }
@@ -53,9 +61,9 @@ export class EditNodeTool implements Tool {
     const graph = await this.fileManager.loadGraphFromSvg(file_path);
 
     for (const node of nodes) {
-      const { id, title, kind, x, y, width, height, corner_radius } = node;
+      const { id, title, kind, x, y, width, height, corner_radius, fillColor, strokeColor, fontColor, strokeWidth, fontSize, fontStyle, fontFamily, opacity } = node;
       
-      graph.editNode({ id, title, kind: kind ? Graph.normalizeKind(kind) : undefined, x, y, width, height, ...(corner_radius && { corner_radius: Number(corner_radius) }) });
+      graph.editNode({ id, title, kind: kind ? Graph.normalizeKind(kind) : undefined, x, y, width, height, ...(corner_radius && { corner_radius: Number(corner_radius) }), fillColor, strokeColor, fontColor, strokeWidth, fontSize, fontStyle, fontFamily, opacity });
     }
 
     await this.fileManager.saveGraphToSvg(graph, file_path);

--- a/src/mcp/LinkNodesTools.ts
+++ b/src/mcp/LinkNodesTools.ts
@@ -27,7 +27,14 @@ export class LinkNodesTool implements Tool {
                 title: { type: 'string', description: 'Connection label (optional)' },
                 dashed: { type: 'boolean', description: 'Whether the connection should be dashed' },
                 reverse: { type: 'boolean', description: 'Whether to reverse the connection direction' },
-                undirected: { type: 'boolean', description: 'Create an undirected edge (no arrows); overrides reverse' }
+                undirected: { type: 'boolean', description: 'Create an undirected edge (no arrows); overrides reverse' },
+                strokeColor: { type: 'string', description: 'Line color (hex, e.g., "#6c8ebf")' },
+                fontColor: { type: 'string', description: 'Label text color (hex, e.g., "#333333")' },
+                strokeWidth: { type: 'number', description: 'Line width in pixels' },
+                fontSize: { type: 'number', description: 'Label font size in pixels' },
+                fontStyle: { type: 'integer', description: 'Font style bitmask: 1=bold, 2=italic, 4=underline (combinable, e.g., 3=bold+italic)' },
+                fontFamily: { type: 'string', description: 'Label font family name (e.g., "Helvetica")' },
+                opacity: { type: 'number', minimum: 0, maximum: 100, description: 'Overall opacity (0=transparent, 100=opaque)' }
               },
               required: ['from', 'to']
             }
@@ -46,11 +53,18 @@ export class LinkNodesTool implements Tool {
     const graph = await this.fileManager.loadGraphFromSvg(file_path);
 
     for (const edge of edges) {
-      const { from, to, title, dashed, reverse, undirected } = edge;
+      const { from, to, title, dashed, reverse, undirected, strokeColor, fontColor, strokeWidth, fontSize, fontStyle, fontFamily, opacity } = edge;
 
       const style = {
         ...(dashed && { dashed: 1 }),
         ...(reverse && { reverse: true }),
+        ...(strokeColor !== undefined && { strokeColor }),
+        ...(fontColor !== undefined && { fontColor }),
+        ...(strokeWidth !== undefined && { strokeWidth }),
+        ...(fontSize !== undefined && { fontSize }),
+        ...(fontStyle !== undefined && { fontStyle }),
+        ...(fontFamily !== undefined && { fontFamily }),
+        ...(opacity !== undefined && { opacity }),
       };
       
       graph.linkNodes({ from, to, title, style, undirected });

--- a/src/mxgraph/jsdom.ts
+++ b/src/mxgraph/jsdom.ts
@@ -5,15 +5,42 @@ const dom = new JSDOM();
 (global as any).window = dom.window;
 global.document = window.document;
 global.XMLSerializer = window.XMLSerializer;
-// Node 24+ made global.navigator (and sometimes location) read-only; avoid crash (mxgraph still works via window.*)
-try {
-  (global as any).navigator = window.navigator;
-} catch {
-  /* ignored on Node 24+ */
+
+// Node 24+ made global.navigator read-only. Try assignment first, then
+// Object.defineProperty, and finally patch individual properties so mxgraph
+// can find things like navigator.appVersion.
+function forceGlobal(name: string, value: any) {
+  try {
+    (global as any)[name] = value;
+    if ((global as any)[name] === value) return;
+  } catch { /* read-only */ }
+  try {
+    Object.defineProperty(global, name, { value, writable: true, configurable: true });
+    if ((global as any)[name] === value) return;
+  } catch { /* still read-only */ }
+  // Last resort: patch missing properties onto the existing global
+  const existing = (global as any)[name];
+  if (existing && typeof existing === 'object') {
+    for (const key of Object.keys(value)) {
+      try { if (!(key in existing)) (existing as any)[key] = value[key]; } catch {}
+    }
+    // Also copy own-property descriptors from the prototype (e.g. appVersion)
+    const proto = Object.getPrototypeOf(value);
+    if (proto) {
+      for (const key of Object.getOwnPropertyNames(proto)) {
+        if (key === 'constructor') continue;
+        try {
+          if (!(key in existing)) {
+            const desc = Object.getOwnPropertyDescriptor(proto, key);
+            if (desc) Object.defineProperty(existing, key, { get: () => value[key], configurable: true });
+          }
+        } catch {}
+      }
+    }
+  }
 }
-try {
-  (global as any).location = window.location;
-} catch {
-  /* ignored on Node 24+ */
-}
+
+forceGlobal('navigator', window.navigator);
+forceGlobal('location', window.location);
+
 global.DOMParser = window.DOMParser;

--- a/src/mxgraph/jsdom.ts
+++ b/src/mxgraph/jsdom.ts
@@ -1,10 +1,19 @@
-import { JSDOM } from "jsdom";
+import { JSDOM } from 'jsdom';
 
 const dom = new JSDOM();
 
 (global as any).window = dom.window;
 global.document = window.document;
-global.XMLSerializer = window.XMLSerializer
-Object.defineProperty(global, 'navigator', { value: window.navigator, writable: true, configurable: true });
-(global as any).location = window.location;
+global.XMLSerializer = window.XMLSerializer;
+// Node 24+ made global.navigator (and sometimes location) read-only; avoid crash (mxgraph still works via window.*)
+try {
+  (global as any).navigator = window.navigator;
+} catch {
+  /* ignored on Node 24+ */
+}
+try {
+  (global as any).location = window.location;
+} catch {
+  /* ignored on Node 24+ */
+}
 global.DOMParser = window.DOMParser;

--- a/src/mxgraph/jsdom.ts
+++ b/src/mxgraph/jsdom.ts
@@ -5,6 +5,6 @@ const dom = new JSDOM();
 (global as any).window = dom.window;
 global.document = window.document;
 global.XMLSerializer = window.XMLSerializer
-global.navigator = window.navigator;
-global.location = window.location;
+Object.defineProperty(global, 'navigator', { value: window.navigator, writable: true, configurable: true });
+(global as any).location = window.location;
 global.DOMParser = window.DOMParser;


### PR DESCRIPTION
This pull request introduces comprehensive support for customizing the visual appearance of nodes and edges in diagrams, including colors, fonts, opacity, and edge routing styles. It updates the codebase, JSON schemas, and documentation to allow users to specify these styling options when adding, editing, or linking nodes, making diagram creation much more flexible and expressive.

The most important changes are:

**Styling Options for Nodes and Edges:**
- Added support for specifying `fillColor`, `strokeColor`, `fontColor`, `strokeWidth`, `fontSize`, `fontStyle`, `fontFamily`, and `opacity` for nodes and edges in the `AddNodeTool`, `EditNodeTool`, and `LinkNodesTool` JSON schemas and logic. These properties are now passed through and applied to diagram elements. [[1]](diffhunk://#diff-e2ee209b9b622aafd7d9251f6210fedde94f469723a69df132382f154aee611cL52-R60) [[2]](diffhunk://#diff-8bb043bde89908aa4d33f640e9ef0a4e67a1c4074938919515ce854a0e4a5935L37-R45) [[3]](diffhunk://#diff-4837349fee9f45c56a564dd32052cd6f25e07c8fffc1f9a80fabe17f14463ec0L30-R58) [[4]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74R38-R73) [[5]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74R204-R244) [[6]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74R258-R265) [[7]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74L200-R280) [[8]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74L211-R291) [[9]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74R304-R314)
- The `README.md` has been updated to document all new styling parameters for nodes and edges, and includes a new example demonstrating their use. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R113) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R193-R222) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R242) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R320-R327)

**Advanced Edge Routing:**
- Introduced options for specifying edge routing style (`edgeStyle`: orthogonal, elbow, entity-relation, segment, straight) and custom waypoints for edges, both in the schema and in the core graph logic. [[1]](diffhunk://#diff-4837349fee9f45c56a564dd32052cd6f25e07c8fffc1f9a80fabe17f14463ec0L30-R58) [[2]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74R38-R73) [[3]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74L200-R280) [[4]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74R304-R314) [[5]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74L354-R459)

**Codebase Improvements and Refactoring:**
- Refactored the style handling in `Graph.ts`, including new utility methods for extracting and merging style overrides, and expanded type definitions for style properties and edge styles. [[1]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74R38-R73) [[2]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74R204-R244)
- Improved imports and formatting for better maintainability and clarity. [[1]](diffhunk://#diff-19916ad513dd172647c2a7f587538d20cc8058a4f8804ba256530a8d5a331b74L1-R15) [[2]](diffhunk://#diff-4837349fee9f45c56a564dd32052cd6f25e07c8fffc1f9a80fabe17f14463ec0L1-R6)

**Build Process:**
- Added a `prepare` script to `package.json` to ensure TypeScript compilation runs on install/publish.

These changes provide much greater flexibility and control over the appearance and layout of diagrams created or edited with this tool.